### PR TITLE
New filter operations, gt and lt, removed mapping for booleans.

### DIFF
--- a/include/WindComp.h
+++ b/include/WindComp.h
@@ -17,6 +17,8 @@
 
 #define WindComp_MINUS_NUM(val1, val2) *(double*)(val1) -= *(double*)(val2)
 
+#define WindComp_LT_NUM(val1, val2) *(double*)(val1) < *(double*)(val2)
+
 unsigned char* WindComp_begin(void);
 const unsigned char* WindComp_end(void);
 
@@ -54,7 +56,7 @@ int WindComp_check_not(void);
 
 // Checks if item in comp buffer is less than arg.
 // Unlike apply functions, this only supports a single argument.
-int WindComp_check_lt(unsigned char* arg);
+int WindComp_check_lt(unsigned char** arg);
 
 // Maps an array of instructions onto the item in the comp buffer.
 // Returns zero if error.

--- a/include/WindComp.h
+++ b/include/WindComp.h
@@ -21,6 +21,8 @@
 
 #define WindComp_LT_NUM(val1, val2) *(double*)(val1) < *(double*)(val2)
 
+#define WindComp_GT_NUM(val1, val2) *(double*)(val1) > *(double*)(val2)
+
 unsigned char* WindComp_begin(void);
 const unsigned char* WindComp_end(void);
 
@@ -61,6 +63,10 @@ int WindComp_check_not(void);
 // Checks if item in comp buffer is less than arg.
 // Unlike apply functions, this only supports a single argument.
 int WindComp_check_lt(unsigned char** arg);
+
+// Checks if item in comp buffer is greater than arg.
+// Unlike apply functions, this only supports a single argument.
+int WindComp_check_gt(unsigned char** arg);
 
 // Maps an array of instructions onto the item in the comp buffer.
 // Returns zero if error.

--- a/include/WindComp.h
+++ b/include/WindComp.h
@@ -51,4 +51,8 @@ unsigned WindComp_apply_minus(unsigned char* args, const unsigned char* argsEnd)
 // Returns zero if error.
 int WindComp_map(unsigned char* ins, const unsigned char* insEnd);
 
+// Filters the current active buffer values against a series of boolean conditions
+// in the load buffer. The value is cleared from comp buffer if it fails filter test.
+int WindComp_filter(unsigned char* ins, const unsigned char* insEnd);
+
 #endif

--- a/include/WindComp.h
+++ b/include/WindComp.h
@@ -52,6 +52,10 @@ unsigned WindComp_apply_minus(unsigned char* args, const unsigned char* argsEnd)
 // Checks if item in comp buffer is true or false after NOT
 int WindComp_check_not(void);
 
+// Checks if item in comp buffer is less than arg.
+// Unlike apply functions, this only supports a single argument.
+int WindComp_check_lt(unsigned char* arg);
+
 // Maps an array of instructions onto the item in the comp buffer.
 // Returns zero if error.
 int WindComp_map(unsigned char* ins, const unsigned char* insEnd);

--- a/include/WindComp.h
+++ b/include/WindComp.h
@@ -17,6 +17,8 @@
 
 #define WindComp_MINUS_NUM(val1, val2) *(double*)(val1) -= *(double*)(val2)
 
+#define WindComp_MULTIPLY_NUM(val1, val2) *(double*)(val1) *= *(double*)(val2)
+
 #define WindComp_LT_NUM(val1, val2) *(double*)(val1) < *(double*)(val2)
 
 unsigned char* WindComp_begin(void);
@@ -48,6 +50,8 @@ void WindComp_apply_not(void);
 unsigned WindComp_apply_plus(unsigned char* args, const unsigned char* argsEnd);
 
 unsigned WindComp_apply_minus(unsigned char* args, const unsigned char* argsEnd);
+
+unsigned WindComp_apply_multiply(unsigned char* args, const unsigned char* argsEnd);
 
 /*/ filtering functions /*/
 

--- a/include/WindComp.h
+++ b/include/WindComp.h
@@ -47,6 +47,11 @@ unsigned WindComp_apply_plus(unsigned char* args, const unsigned char* argsEnd);
 
 unsigned WindComp_apply_minus(unsigned char* args, const unsigned char* argsEnd);
 
+/*/ filtering functions /*/
+
+// Checks if item in comp buffer is true or false after NOT
+int WindComp_check_not(void);
+
 // Maps an array of instructions onto the item in the comp buffer.
 // Returns zero if error.
 int WindComp_map(unsigned char* ins, const unsigned char* insEnd);

--- a/include/WindExec.h
+++ b/include/WindExec.h
@@ -19,4 +19,6 @@ void WindExec_clr(void);
 
 int WindExec_map(void);
 
+int WindExec_filter(void);
+
 #endif

--- a/include/WindLoad.h
+++ b/include/WindLoad.h
@@ -19,6 +19,7 @@ void WindLoad_assign(void);
 void WindLoad_plus(void);
 void WindLoad_minus(void);
 void WindLoad_del(void);
+void WindLoad_lt(void);
 
 // Loads number onto load buffer.
 void WindLoad_number(const char** code);

--- a/include/WindLoad.h
+++ b/include/WindLoad.h
@@ -21,6 +21,7 @@ void WindLoad_minus(void);
 void WindLoad_multiply(void);
 void WindLoad_del(void);
 void WindLoad_lt(void);
+void WindLoad_gt(void);
 
 // Loads number onto load buffer.
 void WindLoad_number(const char** code);

--- a/include/WindLoad.h
+++ b/include/WindLoad.h
@@ -18,6 +18,7 @@ void WindLoad_not(void);
 void WindLoad_assign(void);
 void WindLoad_plus(void);
 void WindLoad_minus(void);
+void WindLoad_multiply(void);
 void WindLoad_del(void);
 void WindLoad_lt(void);
 

--- a/include/WindType.h
+++ b/include/WindType.h
@@ -13,6 +13,7 @@ typedef enum
         WindType_Assign,
         WindType_Plus,
         WindType_Minus,
+        WindType_Lt, // < op
         WindType_Del,
         WindType_Sep
 } WindType;

--- a/include/WindType.h
+++ b/include/WindType.h
@@ -24,7 +24,8 @@ typedef enum
         WindCommand_out,
         WindCommand_push,
         WindCommand_clr,
-        WindCommand_map
+        WindCommand_map,
+        WindCommand_filter
 } WindCommand;
 
 const char* WindType_get_str(WindType type);

--- a/include/WindType.h
+++ b/include/WindType.h
@@ -14,7 +14,8 @@ typedef enum
         WindType_Plus,
         WindType_Minus,
         WindType_Multiply,
-        WindType_Lt, // < op
+        WindType_Lt,
+        WindType_Gt,
         WindType_Del,
         WindType_Sep
 } WindType;

--- a/include/WindType.h
+++ b/include/WindType.h
@@ -13,6 +13,7 @@ typedef enum
         WindType_Assign,
         WindType_Plus,
         WindType_Minus,
+        WindType_Multiply,
         WindType_Lt, // < op
         WindType_Del,
         WindType_Sep

--- a/src/code/WindRun.c
+++ b/src/code/WindRun.c
@@ -8,7 +8,7 @@ int WindRun_exec(const char** code)
         case WindCommand_null:
                 break;
         case WindCommand_out:
-                WindExec_out();
+                (void) WindExec_out();
                 break;
         case WindCommand_push:
                 WindExec_push();

--- a/src/code/WindRun.c
+++ b/src/code/WindRun.c
@@ -19,6 +19,9 @@ int WindRun_exec(const char** code)
         case WindCommand_map:
                 WindExec_map();
                 break;
+        case WindCommand_filter:
+                //handle filter
+                break;
         }
         WindData_load_reset(); // Resets load buf.
         WindState_set_cmd(WindCommand_null);
@@ -212,6 +215,20 @@ int WindRun_command(const char** code)
                                 break;
                         default:
                                 WindState_write_err("Expected command symbol, found 'c%c'", *code[1]);
+                                return 0;
+                        }
+                        break;
+                case 'f':
+                        // Due to only one command that starts with f, this does not use static trie
+                        if((*code)[1] == 'i' && (*code)[2] == 'l' && (*code)[3] == 't' && (*code)[4] == 'e' && (*code)[5] == 'r')
+                        {
+                                *code += 6;
+                                WindState_set_cmd(WindCommand_filter);
+                                goto TRANS_TO_LOAD;
+                        }
+                        else
+                        {
+                                WindState_write_err("Expected command symbol, found 'f%c%c%c'", *code[1], *code[2], *code[3]);
                                 return 0;
                         }
                         break;

--- a/src/code/WindRun.c
+++ b/src/code/WindRun.c
@@ -11,7 +11,7 @@ int WindRun_exec(const char** code)
                 (void) WindExec_out();
                 break;
         case WindCommand_push:
-                WindExec_push();
+                (void) WindExec_push();
                 break;
         case WindCommand_clr:
                 WindExec_clr();

--- a/src/code/WindRun.c
+++ b/src/code/WindRun.c
@@ -95,6 +95,10 @@ int WindRun_load(const char** code)
                         *code += 1;
                         WindLoad_plus();
                         continue;
+                case '*':
+                        *code += 1;
+                        WindLoad_multiply();
+                        continue;
                 case '=':
                         // assign :symbol
                         *code += 1;

--- a/src/code/WindRun.c
+++ b/src/code/WindRun.c
@@ -108,6 +108,10 @@ int WindRun_load(const char** code)
                         *code += 1;
                         WindLoad_lt();
                         continue;
+                case '>':
+                        *code += 1;
+                        WindLoad_gt();
+                        continue;
                 case 'D':
                         if((*code)[1] == 'e' && (*code)[2] == 'l' )
                         {

--- a/src/code/WindRun.c
+++ b/src/code/WindRun.c
@@ -20,7 +20,7 @@ int WindRun_exec(const char** code)
                 WindExec_map();
                 break;
         case WindCommand_filter:
-                //handle filter
+                WindExec_filter();
                 break;
         }
         WindData_load_reset(); // Resets load buf.

--- a/src/code/WindRun.c
+++ b/src/code/WindRun.c
@@ -100,6 +100,10 @@ int WindRun_load(const char** code)
                         *code += 1;
                         WindLoad_assign();
                         continue;
+                case '<':
+                        *code += 1;
+                        WindLoad_lt();
+                        continue;
                 case 'D':
                         if((*code)[1] == 'e' && (*code)[2] == 'l' )
                         {

--- a/src/code/WindType.c
+++ b/src/code/WindType.c
@@ -13,6 +13,7 @@ static const char* WindType_STR_MULTIPLY = "Multiply";
 static const char* WindType_STR_SEP = "Separator";
 static const char* WindType_STR_DEL = "Delete";
 static const char* WindType_STR_LT = "LessThan";
+static const char* WindType_STR_GT = "GreaterThan";
 
 const char* WindType_get_str(WindType type)
 {
@@ -29,5 +30,6 @@ const char* WindType_get_str(WindType type)
         case WindType_Del: return WindType_STR_DEL;
         case WindType_Sep: return WindType_STR_SEP;
         case WindType_Lt: return WindType_STR_LT;
+        case WindType_Gt: return WindType_STR_GT;
         }
 }

--- a/src/code/WindType.c
+++ b/src/code/WindType.c
@@ -9,6 +9,7 @@ static const char* WindType_STR_ASSIGN = "Assign";
 static const char* WindType_STR_NOT = "Not";
 static const char* WindType_STR_PLUS = "Plus";
 static const char* WindType_STR_MINUS = "Minus";
+static const char* WindType_STR_MULTIPLY = "Multiply";
 static const char* WindType_STR_SEP = "Separator";
 static const char* WindType_STR_DEL = "Delete";
 static const char* WindType_STR_LT = "LessThan";
@@ -24,6 +25,7 @@ const char* WindType_get_str(WindType type)
         case WindType_Assign: return WindType_STR_ASSIGN;
         case WindType_Plus: return WindType_STR_PLUS;
         case WindType_Minus: return WindType_STR_MINUS;
+        case WindType_Multiply: return WindType_STR_MULTIPLY;
         case WindType_Del: return WindType_STR_DEL;
         case WindType_Sep: return WindType_STR_SEP;
         case WindType_Lt: return WindType_STR_LT;

--- a/src/code/WindType.c
+++ b/src/code/WindType.c
@@ -11,6 +11,7 @@ static const char* WindType_STR_PLUS = "Plus";
 static const char* WindType_STR_MINUS = "Minus";
 static const char* WindType_STR_SEP = "Separator";
 static const char* WindType_STR_DEL = "Delete";
+static const char* WindType_STR_LT = "LessThan";
 
 const char* WindType_get_str(WindType type)
 {
@@ -25,5 +26,6 @@ const char* WindType_get_str(WindType type)
         case WindType_Minus: return WindType_STR_MINUS;
         case WindType_Del: return WindType_STR_DEL;
         case WindType_Sep: return WindType_STR_SEP;
+        case WindType_Lt: return WindType_STR_LT;
         }
 }

--- a/src/flow/WindComp.c
+++ b/src/flow/WindComp.c
@@ -181,9 +181,33 @@ int WindComp_check_not(void)
         }
 }
 
-int WindComp_check_lt(unsigned char* arg)
+int WindComp_check_lt(unsigned char** arg)
 {
-        return 0;
+        int result = 0;
+        switch(WindComp_BUF[0])
+        {
+        case WindType_Number:
+                switch(**arg)
+                {
+                case WindType_Number:
+                        *arg += 1;
+                        result = WindComp_LT_NUM(WindComp_BODY, *arg);
+                        *arg += sizeof(double);
+                        return result;
+                default:
+                        return 0;
+                }
+        case WindType_Bool:
+                switch(**arg)
+                {
+                case WindType_Bool:
+                        result = WindComp_BUF[1] < (*arg)[1];
+                        *arg += 2;
+                        return result;
+                }
+        default:
+                return 0;
+        }
 }
 
 /*Applies series of operations to item in comp*/
@@ -243,6 +267,10 @@ int WindComp_filter(unsigned char* ins, const unsigned char* insEnd)
                         if(!WindComp_check_not()) goto FILTER_FAILURE;
                         break;
                 case WindType_Lt:
+                        ins++;
+                        if(!WindComp_check_lt(&ins)) goto FILTER_FAILURE;
+                        break;
+                case WindType_Sep:
                         ins++;
                         break;
                 default: return 0;

--- a/src/flow/WindComp.c
+++ b/src/flow/WindComp.c
@@ -2,7 +2,9 @@
 
 static unsigned char WindComp_BUF[WindComp_BUF_SIZE];
 
+// Access to body chunk of comp item.
 static unsigned char* WindComp_BODY = WindComp_BUF + 1;
+// End of comp item.
 static const unsigned char* WindComp_END = WindComp_BUF + WindComp_BUF_SIZE;
 
 static unsigned WindComp_ITEM_LEN = 0;
@@ -164,6 +166,16 @@ unsigned WindComp_apply_minus(unsigned char* args, const unsigned char* argsEnd)
         return mover - args;
 }
 
+int WindComp_check_not(void)
+{
+        switch(WindComp_BUF[0])
+        {
+        case WindBool:
+                return *WindComp_BODY;
+        }
+        return 0;
+}
+
 /*Applies series of operations to item in comp*/
 int WindComp_map(unsigned char* ins, const unsigned char* insEnd)
 {
@@ -210,5 +222,17 @@ int WindComp_map(unsigned char* ins, const unsigned char* insEnd)
 
 int WindComp_filter(unsigned char* ins, const unsigned char* insEnd)
 {
+        unsigned moveChecker = 0;
+        // Active while object has still not failed a filter.
+        while(WindComp_get_len() && ins != insEnd)
+        {
+                switch(*ins)
+                {
+                case WindType_Not:
+                        ins++;
+                        break;
+                default: return 0;
+                }
+        }
         return 1;
 }

--- a/src/flow/WindComp.c
+++ b/src/flow/WindComp.c
@@ -166,6 +166,38 @@ unsigned WindComp_apply_minus(unsigned char* args, const unsigned char* argsEnd)
         return mover - args;
 }
 
+unsigned WindComp_apply_multiply(unsigned char* args, const unsigned char* argsEnd)
+{
+        if(WindComp_BUF[0] != WindType_Number)
+        {
+                WindState_write_err("Attempted to use * operator on type: '%s'", WindType_get_str(WindComp_BUF[0]));
+                return 0;
+        }
+        unsigned char* mover = args;
+        while(mover != argsEnd)
+        {
+                switch(*mover)
+                {
+                case WindType_Number:
+                        mover++;
+                        WindComp_MULTIPLY_NUM(WindComp_BODY, mover);
+                        mover += sizeof(double);
+                        break;
+                case WindType_Bool:
+                        // Adds 1 for true, 0 for False.
+                        mover++;
+                        *(double*)(WindComp_BODY) *= *mover++;
+                        break;
+                case WindType_Sep:
+                        return mover - args;
+                default:
+                        WindState_write_err("Attempted to use * operator on arg with type: '%s'", WindType_get_str(*mover));
+                        return 0;
+                }
+        }
+        return mover - args;
+}
+
 int WindComp_check_not(void)
 {
         switch(WindComp_BUF[0])
@@ -239,6 +271,12 @@ int WindComp_map(unsigned char* ins, const unsigned char* insEnd)
                 case WindType_Minus:
                         ins++;
                         moveChecker = WindComp_apply_minus(ins, insEnd);
+                        if(moveChecker) ins += moveChecker;
+                        else return 0;
+                        break;
+                case WindType_Multiply:
+                        ins++;
+                        moveChecker = WindComp_apply_multiply(ins, insEnd);
                         if(moveChecker) ins += moveChecker;
                         else return 0;
                         break;

--- a/src/flow/WindComp.c
+++ b/src/flow/WindComp.c
@@ -179,6 +179,10 @@ int WindComp_check_not(void)
         default:
                 return 0;
         }
+}
+
+int WindComp_check_lt(unsigned char* arg)
+{
         return 0;
 }
 
@@ -237,6 +241,9 @@ int WindComp_filter(unsigned char* ins, const unsigned char* insEnd)
                 case WindType_Not:
                         ins++;
                         if(!WindComp_check_not()) goto FILTER_FAILURE;
+                        break;
+                case WindType_Lt:
+                        ins++;
                         break;
                 default: return 0;
                 }

--- a/src/flow/WindComp.c
+++ b/src/flow/WindComp.c
@@ -211,9 +211,11 @@ int WindComp_check_lt(unsigned char** arg)
 }
 
 /*Applies series of operations to item in comp*/
+// THROWS with return of 0
 int WindComp_map(unsigned char* ins, const unsigned char* insEnd)
 {
         unsigned moveChecker = 0;
+        int boolResult = 0;
         while(ins != insEnd)
         {
                 switch(*ins)
@@ -244,6 +246,14 @@ int WindComp_map(unsigned char* ins, const unsigned char* insEnd)
                         ins++;
                         WindComp_clear();
                         return 1;
+                case WindType_Lt:
+                        ins++;
+                        // todo: refactor
+                        boolResult = WindComp_check_lt(&ins);
+                        WindComp_BUF[0] = WindType_Bool;
+                        WindComp_BUF[1] = boolResult;
+                        WindComp_ITEM_LEN = sizeof(unsigned char) + sizeof(unsigned char);
+                        break;
                 case WindType_Sep:
                         ins++;
                         break;
@@ -254,6 +264,7 @@ int WindComp_map(unsigned char* ins, const unsigned char* insEnd)
         return 1;
 }
 
+// todo: throw or not?
 int WindComp_filter(unsigned char* ins, const unsigned char* insEnd)
 {
         //unsigned moveChecker = 0;

--- a/src/flow/WindComp.c
+++ b/src/flow/WindComp.c
@@ -303,7 +303,7 @@ int WindComp_map(unsigned char* ins, const unsigned char* insEnd)
         return 1;
 }
 
-// todo: throw or not?
+
 int WindComp_filter(unsigned char* ins, const unsigned char* insEnd)
 {
         //unsigned moveChecker = 0;
@@ -323,7 +323,9 @@ int WindComp_filter(unsigned char* ins, const unsigned char* insEnd)
                 case WindType_Sep:
                         ins++;
                         break;
-                default: return 0;
+                default:
+                        WindState_write_err("Cannot run filter operation with type: '%s'", WindType_get_str(*ins));
+                        return 0;
                 }
         }
         return 1;

--- a/src/flow/WindComp.c
+++ b/src/flow/WindComp.c
@@ -242,12 +242,41 @@ int WindComp_check_lt(unsigned char** arg)
         }
 }
 
+int WindComp_check_gt(unsigned char** arg)
+{
+        int result = 0;
+        switch(WindComp_BUF[0])
+        {
+        case WindType_Number:
+                switch(**arg)
+                {
+                case WindType_Number:
+                        *arg += 1;
+                        result = WindComp_GT_NUM(WindComp_BODY, *arg);
+                        *arg += sizeof(double);
+                        return result;
+                default:
+                        return 0;
+                }
+        case WindType_Bool:
+                switch(**arg)
+                {
+                case WindType_Bool:
+                        result = WindComp_BUF[1] > (*arg)[1];
+                        *arg += 2;
+                        return result;
+                }
+        default:
+                return 0;
+        }
+}
+
 /*Applies series of operations to item in comp*/
 // THROWS with return of 0
 int WindComp_map(unsigned char* ins, const unsigned char* insEnd)
 {
         unsigned moveChecker = 0;
-        int boolResult = 0;
+        //int boolResult = 0;
         while(ins != insEnd)
         {
                 switch(*ins)
@@ -284,14 +313,6 @@ int WindComp_map(unsigned char* ins, const unsigned char* insEnd)
                         ins++;
                         WindComp_clear();
                         return 1;
-                case WindType_Lt:
-                        ins++;
-                        // todo: refactor
-                        boolResult = WindComp_check_lt(&ins);
-                        WindComp_BUF[0] = WindType_Bool;
-                        WindComp_BUF[1] = boolResult;
-                        WindComp_ITEM_LEN = sizeof(unsigned char) + sizeof(unsigned char);
-                        break;
                 case WindType_Sep:
                         ins++;
                         break;
@@ -319,6 +340,10 @@ int WindComp_filter(unsigned char* ins, const unsigned char* insEnd)
                 case WindType_Lt:
                         ins++;
                         if(!WindComp_check_lt(&ins)) goto FILTER_FAILURE;
+                        break;
+                case WindType_Gt:
+                        ins++;
+                        if(!WindComp_check_gt(&ins)) goto FILTER_FAILURE;
                         break;
                 case WindType_Sep:
                         ins++;

--- a/src/flow/WindComp.c
+++ b/src/flow/WindComp.c
@@ -207,3 +207,8 @@ int WindComp_map(unsigned char* ins, const unsigned char* insEnd)
         }
         return 1;
 }
+
+int WindComp_filter(unsigned char* ins, const unsigned char* insEnd)
+{
+        return 1;
+}

--- a/src/flow/WindComp.c
+++ b/src/flow/WindComp.c
@@ -258,6 +258,7 @@ int WindComp_map(unsigned char* ins, const unsigned char* insEnd)
                         ins++;
                         break;
                 default:
+                        WindState_write_err("Cannot map argument of type: '%s'", WindType_get_str(*ins));
                         return 0;
                 }
         }

--- a/src/flow/WindComp.c
+++ b/src/flow/WindComp.c
@@ -170,8 +170,14 @@ int WindComp_check_not(void)
 {
         switch(WindComp_BUF[0])
         {
-        case WindBool:
-                return *WindComp_BODY;
+        case WindType_Bool:
+                return !(*WindComp_BODY);
+        case WindType_None:
+                return 1;
+        case WindType_Number:
+                return !(*(double*)(WindComp_BODY));
+        default:
+                return 0;
         }
         return 0;
 }
@@ -222,17 +228,21 @@ int WindComp_map(unsigned char* ins, const unsigned char* insEnd)
 
 int WindComp_filter(unsigned char* ins, const unsigned char* insEnd)
 {
-        unsigned moveChecker = 0;
+        //unsigned moveChecker = 0;
         // Active while object has still not failed a filter.
-        while(WindComp_get_len() && ins != insEnd)
+        while(ins != insEnd)
         {
                 switch(*ins)
                 {
                 case WindType_Not:
                         ins++;
+                        if(!WindComp_check_not()) goto FILTER_FAILURE;
                         break;
                 default: return 0;
                 }
         }
+        return 1;
+FILTER_FAILURE:
+        WindComp_clear();
         return 1;
 }

--- a/src/flow/WindExec.c
+++ b/src/flow/WindExec.c
@@ -24,6 +24,7 @@ void WindExec_clr(void)
 
 int WindExec_map(void)
 {
+        if(!WindData_load_len()) return 1;
         unsigned char* loadStart;
         const unsigned char* loadStop;
 
@@ -50,6 +51,7 @@ int WindExec_map(void)
 
 int WindExec_filter(void)
 {
+        if(!WindData_load_len()) return 1;
         unsigned char* loadStart;
         const unsigned char* loadStop;
 

--- a/src/flow/WindExec.c
+++ b/src/flow/WindExec.c
@@ -47,3 +47,27 @@ int WindExec_map(void)
         WindData_active_switch();
         return 1;
 }
+
+int WindExec_filter(void)
+{
+        unsigned char* loadStart;
+        const unsigned char* loadStop;
+
+        unsigned char* activeStart = WindData_active_start();
+        const unsigned char* activeStop = WindData_active_ptr();
+
+        WindData_inactive_reset(); // resets inactive for writing new data.
+        while(activeStart != activeStop)
+        {
+                loadStart = WindData_load_start();
+                loadStop = WindData_load_ptr();
+                // loads into the comp buf.
+                activeStart += WindComp_write_typed(activeStart);
+                //if(!WindComp_map(loadStart, loadStop)) return 0;
+
+                WindData_inactive_write(WindComp_begin(), WindComp_get_len());
+        }
+
+        WindData_active_switch();
+        return 1;
+}

--- a/src/flow/WindExec.c
+++ b/src/flow/WindExec.c
@@ -63,7 +63,7 @@ int WindExec_filter(void)
                 loadStop = WindData_load_ptr();
                 // loads into the comp buf.
                 activeStart += WindComp_write_typed(activeStart);
-                //if(!WindComp_map(loadStart, loadStop)) return 0;
+                if(!WindComp_filter(loadStart, loadStop)) return 0;
 
                 WindData_inactive_write(WindComp_begin(), WindComp_get_len());
         }

--- a/src/flow/WindLoad.c
+++ b/src/flow/WindLoad.c
@@ -15,6 +15,7 @@ static unsigned char WIND_SEP[] = {WindType_Sep};
 static unsigned char WIND_PLUS[] = {WindType_Plus};
 static unsigned char WIND_MINUS[] = {WindType_Minus};
 static unsigned char WIND_DEL[] = {WindType_Del};
+static unsigned char WIND_LT[] = {WindType_Lt};
 
 // Used as default initalizer for moved C-string result.
 static char* NUM_RESULT_INIT = "";
@@ -63,6 +64,11 @@ void WindLoad_minus(void)
 void WindLoad_del(void)
 {
         WindData_load_write(WIND_DEL, sizeof(WIND_DEL));
+}
+
+void WindLoad_lt(void)
+{
+        WindData_load_write(WIND_LT, sizeof(WIND_LT));
 }
 
 void WindLoad_number(const char** code)

--- a/src/flow/WindLoad.c
+++ b/src/flow/WindLoad.c
@@ -17,6 +17,7 @@ static unsigned char WIND_MINUS[] = {WindType_Minus};
 static unsigned char WIND_MULTIPLY[] = {WindType_Multiply};
 static unsigned char WIND_DEL[] = {WindType_Del};
 static unsigned char WIND_LT[] = {WindType_Lt};
+static unsigned char WIND_GT[] = {WindType_Gt};
 
 // Used as default initalizer for moved C-string result.
 static char* NUM_RESULT_INIT = "";
@@ -75,6 +76,11 @@ void WindLoad_del(void)
 void WindLoad_lt(void)
 {
         WindData_load_write(WIND_LT, sizeof(WIND_LT));
+}
+
+void WindLoad_gt(void)
+{
+        WindData_load_write(WIND_GT, sizeof(WIND_GT));
 }
 
 void WindLoad_number(const char** code)

--- a/src/flow/WindLoad.c
+++ b/src/flow/WindLoad.c
@@ -14,6 +14,7 @@ static unsigned char WIND_ASSIGN[] = {WindType_Assign};
 static unsigned char WIND_SEP[] = {WindType_Sep};
 static unsigned char WIND_PLUS[] = {WindType_Plus};
 static unsigned char WIND_MINUS[] = {WindType_Minus};
+static unsigned char WIND_MULTIPLY[] = {WindType_Multiply};
 static unsigned char WIND_DEL[] = {WindType_Del};
 static unsigned char WIND_LT[] = {WindType_Lt};
 
@@ -59,6 +60,11 @@ void WindLoad_plus(void)
 void WindLoad_minus(void)
 {
         WindData_load_write(WIND_MINUS, sizeof(WIND_MINUS));
+}
+
+void WindLoad_multiply(void)
+{
+        WindData_load_write(WIND_MULTIPLY, sizeof(WIND_MULTIPLY));
 }
 
 void WindLoad_del(void)

--- a/src/flow/WindState.c
+++ b/src/flow/WindState.c
@@ -93,5 +93,8 @@ void WindState_print_cmd(void)
         case WindCommand_map:
                 printf("map");
                 break;
+        case WindCommand_filter:
+                printf("filter");
+                break;
         }
 }

--- a/src/main/Main.c
+++ b/src/main/Main.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <string.h>
+#include "IOUtil.h"
 #include "WindRun.h"
 
 
@@ -17,6 +18,7 @@ int main(int argc, char const *argv[]) {
         else if(!strcmp(argv[1], "-d"))
         {
                 WindRun_code(argv[2]);
+                IOUtil_debug();
         }
         else
         {

--- a/src/main/Main.c
+++ b/src/main/Main.c
@@ -1,5 +1,7 @@
 #include <stdio.h>
 #include <string.h>
+#include <time.h>
+
 #include "IOUtil.h"
 #include "WindRun.h"
 
@@ -13,6 +15,15 @@ int main(int argc, char const *argv[]) {
         else if(!strcmp(argv[1], "-c"))
         {
                 WindRun_code(argv[2]);
+        }
+        // Timed option
+        else if(!strcmp(argv[1], "-t"))
+        {
+                clock_t start, end;
+                start = clock();
+                WindRun_code(argv[2]);
+                end = clock();
+                printf("Time: %f\n", (end-start)/(double)CLOCKS_PER_SEC);
         }
         // debug option
         else if(!strcmp(argv[1], "-d"))

--- a/src/util/IOUtil.c
+++ b/src/util/IOUtil.c
@@ -78,8 +78,14 @@ void IOUtil_debug(void)
         printf("Command: ");
         WindState_print_cmd();
         puts("\n..........Data.........");
-        printf("Load Buffer: -> [");
+        printf("Load Buffer: -> [ ");
         IOUtil_print(WindData_load_begin(), WindData_load_ptr());
+        printf("]\n");
+        printf("Active Buffer: -> [ ");
+        IOUtil_print(WindData_active_begin(), WindData_active_ptr());
+        printf("]\n");
+        printf("Inactive Buffer: -> [ ");
+        IOUtil_print(WindData_inactive_begin(), WindData_inactive_ptr());
         printf("]\n");
         puts("________________________");
 }

--- a/src/util/IOUtil.c
+++ b/src/util/IOUtil.c
@@ -44,6 +44,10 @@ int IOUtil_print(const unsigned char* start, const unsigned char* end)
                         start++;
                         printf("- ");
                         break;
+                case WindType_Multiply:
+                        start++;
+                        printf("* ");
+                        break;
                 case WindType_Lt:
                         start++;
                         printf("< ");

--- a/src/util/IOUtil.c
+++ b/src/util/IOUtil.c
@@ -79,7 +79,7 @@ void IOUtil_debug(void)
         WindState_print_err(); //other func
         printf("Mode: ");
         WindState_print_mode();
-        printf("Command: ");
+        printf("\nCommand: ");
         WindState_print_cmd();
         puts("\n..........Data.........");
         printf("Load Buffer: -> [ ");

--- a/src/util/IOUtil.c
+++ b/src/util/IOUtil.c
@@ -52,6 +52,10 @@ int IOUtil_print(const unsigned char* start, const unsigned char* end)
                         start++;
                         printf("< ");
                         break;
+                case WindType_Gt:
+                        start++;
+                        printf("> ");
+                        break;
                 case WindType_Del:
                         start++;
                         printf("Del ");

--- a/src/util/IOUtil.c
+++ b/src/util/IOUtil.c
@@ -44,6 +44,10 @@ int IOUtil_print(const unsigned char* start, const unsigned char* end)
                         start++;
                         printf("- ");
                         break;
+                case WindType_Lt:
+                        start++;
+                        printf("< ");
+                        break;
                 case WindType_Del:
                         start++;
                         printf("Del ");


### PR DESCRIPTION
## Summary

This Pill Request adds two new filter operators, gt and lt.  These symbolize the traditional `>` and `<` operators respectively. They can be applied via the `filter` command, such as

```
$ ./bin/Wind -d "push 5 6 77 44 -> out -> filter > 10 -> out -> filter < 76 -> out"
[ 5 6 77 44 ]
[ 77 44 ]
[ 44 ]
_____Wind___Debug_______
..........State.........
Has Error: false
Mode: Command
Command: null
..........Data.........
Load Buffer: -> [ ]
Active Buffer: -> [ 44 ]
Inactive Buffer: -> [ 77 44 ]
________________________
```
These types allow more precise  filtering. Many more will be added in the near future.